### PR TITLE
Renamed runinject and alias to var to simplify concepts

### DIFF
--- a/internal/hof/flow/testdata/static-website-project/defs/ec2.cue
+++ b/internal/hof/flow/testdata/static-website-project/defs/ec2.cue
@@ -10,7 +10,7 @@ ec2: module: ec2_instance: schemas.#ModuleEC2 & {
 	name:          "\(common.project_name)-instance"
 	ami:           "ami-0c55b159cbfafe1f0" // Amazon Linux 2 AMI (HVM), SSD Volume Type
 	instance_type: "t2.micro"
-	subnet_id:     string | *null @runinject(public_subnet_id)
+	subnet_id:     string | *null @var(public_subnet_id)
 	user_data: """
 		#!/bin/bash
 		amazon-linux-extras install docker
@@ -18,7 +18,7 @@ ec2: module: ec2_instance: schemas.#ModuleEC2 & {
 		usermod -a -G docker ec2-user
 		
 		# Save RDS endpoint to a file
-		echo "@runinject(rds_endpoint)" > /home/ec2-user/rds_endpoint.txt
+		echo "@var(rds_endpoint)" > /home/ec2-user/rds_endpoint.txt
 		
 		# Run a container with the RDS endpoint as an environment variable
 		docker run -d -p 80:80 -e RDS_ENDPOINT=$(cat /home/ec2-user/rds_endpoint.txt) nginx:latest

--- a/internal/hof/flow/testdata/static-website-project/defs/rds.cue
+++ b/internal/hof/flow/testdata/static-website-project/defs/rds.cue
@@ -17,8 +17,8 @@ rds: {
                 allocated_storage:       5 
                 username:                "\(common.db_username)"
                 password:                "\(common.db_password)" // Assuming `common.db_password` is defined
-                db_subnet_group_name:    string | *null @runinject(subnet_group_ids)
-                vpc_security_group_ids:  [string] | *null @runinject(default_security_group_id)
+                db_subnet_group_name:    string | *null @var(subnet_group_ids)
+                vpc_security_group_ids:  [string] | *null @var(default_security_group_id)
                 parameter_group_name:    "\(common.db_parameter_group_name)"
                 publicly_accessible:     true
                 skip_final_snapshot:     true

--- a/internal/hof/flow/testdata/static-website-project/defs/vpc.cue
+++ b/internal/hof/flow/testdata/static-website-project/defs/vpc.cue
@@ -29,7 +29,7 @@ subnet_group: {
 	resource: {
 		aws_db_subnet_group: education: {
 			name: "education"
-			subnet_ids: [...string] | *null @runinject(public_subnet_ids)
+			subnet_ids: [...string] | *null @var(public_subnet_ids)
 			tags: {
 				Name: "Education"
 			}

--- a/internal/hof/flow/testdata/static-website-project/website_install.tf.cue
+++ b/internal/hof/flow/testdata/static-website-project/website_install.tf.cue
@@ -22,25 +22,25 @@ install_static_website: {
 		config: defs.vpc
 		exports: [{
 			path:  ".module.vpc.aws_vpc.this[0].id"
-			alias: "vpc_id"
+			var: "vpc_id"
 		}, {
 			path:  ".module.vpc.aws_subnet.public[].id"
-			alias: "public_subnet_ids"
+			var: "public_subnet_ids"
 		}, {
 			path:  ".module.vpc.aws_subnet.public[0].id"
-			alias: "public_subnet_id"
+			var: "public_subnet_id"
 		}, {
 			path:  ".module.vpc.aws_subnet.private[].id"
-			alias: "private_subnet_ids"
+			var: "private_subnet_ids"
 		}, {
 			path:  ".module.vpc.aws_vpc.this[0].cidr_block"
-			alias: "vpc_cidr_block"
+			var: "vpc_cidr_block"
 		}, {
 			path:  ".module.vpc.aws_eip.nat[].public_ip"
-			alias: "nat_public_ips"
+			var: "nat_public_ips"
 		}, {
 			path:  ".module.vpc.aws_default_security_group.this[].id"
-			alias: "default_security_group_id"
+			var: "default_security_group_id"
 		}]
 	}
 
@@ -50,7 +50,7 @@ install_static_website: {
 		config: defs.subnet_group
 		exports: [{
 			path:  ".aws_db_subnet_group.this[0].id"
-			alias: "subnet_group_ids"
+			var: "subnet_group_ids"
 		}]
 	}
 
@@ -60,7 +60,7 @@ install_static_website: {
 		config: defs.rds
 		exports: [{
 			path:  ".aws_db_instance.this[0].endpoint"
-			alias: "rds_endpoint"
+			var: "rds_endpoint"
 		}]
 	}
 

--- a/internal/hof/flow/testdata/tasks/cueform/s3.tf.cue
+++ b/internal/hof/flow/testdata/tasks/cueform/s3.tf.cue
@@ -68,7 +68,7 @@ tasks: {
 		dep:    setup_providers
 		config: #aws_availability_zones
 		exports: [{
-			alias: "available_zones"
+			var: "available_zones"
 			path:  ".data.aws_availability_zones.available.id"
 		}]
 	}
@@ -83,10 +83,5 @@ tasks: {
 		@task(opentf.TF)
 		dep: [setup_s3]
 		config: #s3BucketConfig1
-	}
-
-	done: {
-		@task(os.Stdout)
-		text: "S3 bucket setup completed.\n"
 	}
 }

--- a/internal/hof/lib/hof/lang.go
+++ b/internal/hof/lib/hof/lang.go
@@ -19,7 +19,7 @@ const (
 	MantisTaskExports = "exports"
 
 	// ExportsExtension is the file extension for Exports language files
-	MantisTaskAlias = "alias"
+	MantisVar = "var"
 
 	// MantisTaskPath is the default path for task outputs
 	MantisTaskPath = "path"


### PR DESCRIPTION
Simplified the syntax for exporting vars and using them as dynamic variables.

---Export syntax for a terraform task---
	get_azs_data: {
		@task(opentf.TF)
		dep:    setup_providers
		config: #aws_availability_zones
		exports: [{
			var: "available_zones"
			path:  ".data.aws_availability_zones.available.id"
		}]
	}
----- Usage syntax in a configuration or a another task -----
	resource: {
		"aws_s3_bucket": {
			"otfork-sample-bucket": {
				bucket: "otfork-sample-bucket"
				tags: {
					Name:        _  | *null @var(available_zones)
					Environment: "dev"
				}
			}
		}
	}